### PR TITLE
mDNS fix and env changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pioenvs
 .clang_complete
 .gcc-flags.json
+.piolibdeps
 *~

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,35 +21,44 @@
 env_default = emonesp
 data_dir = src/data
 
+[common]
+version = -DBUILD_TAG=2.0.0
+#MQTT: https://github.com/knolleary/pubsubclient
+lib_deps = PubSubClient@2.6
+
 [env:emonesp]
-platform = espressif
+platform = espressif8266
 framework = arduino
 board = esp12e
-#MQTT: https://github.com/knolleary/pubsubclient
-lib_install= 89
-src_build_flags = -DBUILD_TAG=2.0.0
+lib_deps = ${common.lib_deps}
+src_build_flags = ${common.version}
+
+[env:emonesp_ota]
+platform = espressif8266
+framework = arduino
+board = esp12e
+upload_port = emonesp.local
+lib_deps = ${common.lib_deps}
+src_build_flags = ${common.version}
 
 [env:emonesp_spiffs]
-platform = espressif
+platform = espressif8266
 framework = arduino
 board = esp12e
-# MQTT: https://github.com/knolleary/pubsubclient
-lib_install= 89
+lib_deps = ${common.lib_deps}
+src_build_flags = ${common.version}
 upload_flags = --spiffs
-src_build_flags = -DBUILD_TAG=2.0.0
 
 [env:emonesp_deploy]
-platform = espressif
+platform = espressif8266
 framework = arduino
 board = esp12e
-# MQTT: https://github.com/knolleary/pubsubclient
-lib_install= 89
+lib_deps = ${common.lib_deps}
 src_build_flags = !echo '-DBUILD_TAG='${TRAVIS_TAG:-"0.0.0"}
 
 [env:emonesp01]
-platform = espressif
+platform = espressif8266
 framework = arduino
 board = esp01
-#MQTT: https://github.com/knolleary/pubsubclient
-lib_install= 89
-src_build_flags = -DBUILD_TAG=2.0.0 -DESP01
+lib_deps = ${common.lib_deps}
+src_build_flags = ${common.version} -DESP01

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ platform = espressif8266
 framework = arduino
 board = esp12e
 lib_deps = ${common.lib_deps}
-src_build_flags = !echo '-DBUILD_TAG='${TRAVIS_TAG:-"0.0.0"}
+src_build_flags = !echo $((test -z "$TRAVIS_TAG" && echo "${common.version}") || echo "-DBUILD_TAG=$TRAVIS_TAG")
 
 [env:emonesp01]
 platform = espressif8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ platform = espressif8266
 framework = arduino
 board = esp12e
 lib_deps = ${common.lib_deps}
-src_build_flags = !echo $((test -z "$TRAVIS_TAG" && echo "${common.version}") || echo "-DBUILD_TAG=$TRAVIS_TAG")
+src_build_flags = !echo $((test -z $TRAVIS_TAG && echo '${common.version}') || echo '-DBUILD_TAG='$TRAVIS_TAG)
 
 [env:emonesp01]
 platform = espressif8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ platform = espressif8266
 framework = arduino
 board = esp12e
 lib_deps = ${common.lib_deps}
-src_build_flags = !echo $((test -z $TRAVIS_TAG && echo '${common.version}') || echo '-DBUILD_TAG='$TRAVIS_TAG)
+src_build_flags = !(test -z $TRAVIS_TAG && echo '${common.version}') || echo '-DBUILD_TAG='$TRAVIS_TAG
 
 [env:emonesp01]
 platform = espressif8266

--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -46,9 +46,12 @@ const char* u_host = "217.9.195.227";
 const char* u_url = "/esp/firmware.php";
 const char* firmware_update_path = "/upload";
 
+extern const char *esp_hostname;
+
 void ota_setup()
 {
   // Start local OTA update server
+  ArduinoOTA.setHostname(esp_hostname);
   ArduinoOTA.begin();
 
   // Setup firmware upload


### PR DESCRIPTION
ArduinoOTA calls MDNS.begin with no hostname so removed the configured name. Now sets the same hostname as the main mDNS config.

Also added some changes the Platform IO envs;
- Added env to that will upload OTA from the IDE. 
- Removed some of the duplication in the different configs using the template feature of PlatformIO 3.1.0
- Use library names for the dependency
