### PR TITLE
fix: website did not show up in Safari browser

### DIFF
--- a/src/data/config.js
+++ b/src/data/config.js
@@ -19,7 +19,10 @@ function scaleString(string, scale, precision) {
   return tmpval.toFixed(precision);
 }
 
-function BaseViewModel(defaults, remoteUrl, mappings = {}) {
+function BaseViewModel(defaults, remoteUrl, mappings) {
+  if(mappings === undefined){
+   mappings = {};
+  }
   var self = this;
   self.remoteUrl = remoteUrl;
 
@@ -28,7 +31,10 @@ function BaseViewModel(defaults, remoteUrl, mappings = {}) {
   self.fetching = ko.observable(false);
 }
 
-BaseViewModel.prototype.update = function (after = function () { }) {
+BaseViewModel.prototype.update = function (after) {
+  if(after === undefined){
+   after = function () { };
+  }
   var self = this;
   self.fetching(true);
   $.get(self.remoteUrl, function (data) {
@@ -109,7 +115,10 @@ function LastValuesViewModel() {
   self.fetching = ko.observable(false);
   self.values = ko.mapping.fromJS([]);
 
-  self.update = function (after = function () { }) {
+  self.update = function (after) {
+    if(after === undefined){
+     after = function () { };
+    }
     self.fetching(true);
     $.get(self.remoteUrl, function (data) {
       // Transform the data into somethinf a bit easier to handle as a binding
@@ -363,4 +372,3 @@ document.getElementById("restart").addEventListener("click", function (e) {
 //document.getElementById("upload").addEventListener("click", function(e) {
 //  window.location.href='/upload'
 //});
-


### PR DESCRIPTION
Hi,

after I updated the EmonESP to version 2.2.0 it didn't show the content in Safari browser any longer, just displaying "Loading, please wait ...":
![bildschirmfoto 2017-09-19 um 01 09 56](https://user-images.githubusercontent.com/29459232/30569334-aad58abc-9cda-11e7-908f-11ee69320b15.png)

But luckily the developer tools showed this error: `SyntaxError: Unexpected token '='. Expected a ')' or a ',' after a parameter declaration.'` and according to this answer: https://stackoverflow.com/a/37395163 the problem is that safari doesn't like variable assignment in a function declaration. So I did give it a try and changed the code in src/data/config.js and now it's working again in Safari :)

![bildschirmfoto 2017-09-19 um 01 43 44](https://user-images.githubusercontent.com/29459232/30569613-1ac44bfa-9cdc-11e7-87d8-c5190f9b09d4.png)

But as I do not yet fully understand the code, please check if the changes do not have any side effects. 

