### PR TITLE
reset connection error count on successful connection

### DIFF
--- a/src/emoncms.cpp
+++ b/src/emoncms.cpp
@@ -75,6 +75,7 @@ void emoncms_publish(String data)
   if (result == "ok"){
     packets_success++;
     emoncms_connected = true;
+    emoncms_connection_error_count = 0;
   }
   else{
     emoncms_connected=false;


### PR DESCRIPTION
See forum thread https://community.openenergymonitor.org/t/what-does-psent-and-psuccess-indicate/6165?u=pb66.
Currently 5 failed connections per month will cause an unnecessary reset every 6 months or a period of network issues resulting in a count of 29, will forever require a perfect connection to avoid a reset, one missed connection and the 30 limit will be hit. In both cases the count should be reset to 0 following a successful connection. (Fixes https://github.com/openenergymonitor/EmonESP/issues/32)