### PR TITLE
Fix for #78

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -120,7 +120,7 @@ lib_deps =
   PubSubClient@2.6
   ESP Async WebServer@1.2.3
   ESPAsyncTCP@1.2.2
-  NTPClient@3.1.0
+  arduino-libraries/NTPClient@3.1.0
   ArduinoJson@6.15.1
   Micro Debug@0.0.4
   ConfigJson@0.0.4


### PR DESCRIPTION
Explicitly reference the Arduino version of the NTPClient library to resolve warning.